### PR TITLE
Add travis and hound CI support

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,8 @@
+ruby:
+  config_file: .rubocop.yml
+
+java_script:
+  enabled: false
+
+scss:
+  enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ rvm:
   - 2.1
   - 2.2
 
-bundler_args: --without development integration kitchen_docker kitchen_vagrant kitchen_cloud kitchen_common
+bundler_args: --without development integration kitchen_docker kitchen_vagrant kitchen_cloud
 
 env:
   - USE_SYSTEM_GECODE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+rvm:
+  - 2.1
+  - 2.2
+
+bundler_args: --without development integration kitchen_docker kitchen_vagrant kitchen_cloud kitchen_common
+
+env:
+  - USE_SYSTEM_GECODE=1
+
+before_install:
+  - sudo apt-get -y -qq install libgecode-dev
+
+script:
+  - bundle exec rake travis:ci

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,35 @@
+source 'https://rubygems.org'
+
+group :unit do
+  gem 'berkshelf', '~> 3.2.0'
+  gem 'chefspec',  '~> 4.1.0'
+end
+
+group :lint do
+  gem 'foodcritic', '~> 4.0'
+  gem 'rubocop', '~> 0.29.1'
+end
+
+group :kitchen_common do
+  gem 'test-kitchen', '~> 1.2'
+end
+
+group :kitchen_docker do
+  gem 'kitchen-docker', '~> 1.5.0'
+end
+
+group :kitchen_vagrant do
+  gem 'kitchen-vagrant', '~> 0.11'
+end
+
+group :kitchen_cloud do
+  gem 'kitchen-ec2'
+end
+
+group :integration do
+  gem 'serverspec'
+end
+
+group :development do
+  gem 'rake'
+end

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 prometheus Cookbook
 =====================
+[![Build Status](https://travis-ci.org/rayrod2030/chef-prometheus.svg?branch=master)](https://travis-ci.org/rayrod2030/chef-prometheus?branch=master)
 
 This cookbook installs the [Prometheus][] monitoring system and time-series database.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,44 @@
+require 'bundler/setup'
+require 'rubocop/rake_task'
+require 'foodcritic'
+require 'kitchen'
+require 'rspec/core/rake_task'
+
+# Unit Tests. rspec/chefspec
+RSpec::Core::RakeTask.new(:unit)
+
+# Style tests. Rubocop and Foodcritic
+namespace :style do
+  desc 'Run Ruby style checks'
+  RuboCop::RakeTask.new(:ruby)
+
+  desc 'Run Chef style checks'
+  FoodCritic::Rake::LintTask.new(:chef) do |t|
+    t.options = {
+      fail_tags: ['any']
+    }
+  end
+end
+
+desc 'Run all style checks'
+task style: ['style:chef', 'style:ruby']
+
+# Integration tests. Kitchen.ci
+namespace :integration do
+  desc 'Run Test Kitchen with Vagrant'
+  task :vagrant do
+    Kitchen.logger = Kitchen.default_file_logger
+    Kitchen::Config.new.instances.each do |instance|
+      instance.test(:always)
+    end
+  end
+end
+
+# We cannot run Test Kitchen on Travis CI yet...
+namespace :travis do
+  desc 'Run tests on Travis'
+  task ci: %w(style unit)
+end
+
+# The default rake task should just run it all
+task default: ['travis:ci', 'integration']


### PR DESCRIPTION
Travis will run our unit and style checks.

Houndci will run rubocop-as-a-service for ruby linting.