### PR TITLE
Prometheus conf template

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,8 @@ NumericLiterals:
   Enabled: false
 Style/StringLiterals:
   Enabled: true
-  EnforcedStyle: double_quotes
+  EnforcedStyle: single_quotes
 Metrics/LineLength:
+  Enabled: false
+Style/ExtraSpacing:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,8 @@ MethodLength:
   Enabled: false
 NumericLiterals:
   Enabled: false
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+Metrics/LineLength:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - vendor/**
+    - .kitchen/**
 
 ClassLength:
   Enabled: false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,14 @@ default['prometheus']['source']['use_existing_user']                            
 # Location for Prometheus pre-compiiled binary.
 default['prometheus']['binary']['url']                                                    = ''
 
+# Prometheus job configuration chef template name.
+default['prometheus']['job_config_template_name']                                         = 'prometheus.conf.erb'
+
+# Prometheus custom configuration cookbook.  Use this if you'd like to bypass the
+# default prometheus cookbook job configuration template and implement your own
+# templates and recipes to configure Prometheus jobs.
+default['prometheus']['job_config_cookbook_name']                                         = 'prometheus'
+
 # FLAGS Section: Any attributes defined under the flags hash will be used to
 # generate the command line flags for the Prometheus executable.
 

--- a/templates/default/prometheus.conf.erb
+++ b/templates/default/prometheus.conf.erb
@@ -1,0 +1,30 @@
+# Global default settings.
+global {
+  scrape_interval: "15s"     # By default, scrape targets every 15 seconds.
+  evaluation_interval: "15s" # By default, evaluate rules every 15 seconds.
+
+  # Attach these extra labels to all timeseries collected by this Prometheus instance.
+  labels: {
+    label: {
+      name: "monitor"
+      value: "codelab-monitor"
+    }
+  }
+
+  # Load and evaluate rules in this file every 'evaluation_interval' seconds. This field may be repeated.
+  #rule_file: "prometheus.rules"
+}
+
+# A job definition containing exactly one endpoint to scrape: Here it's prometheus itself.
+job: {
+  # The job name is added as a label `job={job-name}` to any timeseries scraped from this job.
+  name: "prometheus"
+  # Override the global default and scrape targets from this job every 5 seconds.
+  scrape_interval: "5s"
+
+  # Let's define a group of targets to scrape for this job. In this case, only one.
+  target_group: {
+    # These endpoints are scraped via HTTP.
+    target: "http://localhost:9090/metrics"
+  }
+}


### PR DESCRIPTION
Busted out the prometheus.conf file into it's own template which is
static for now and simply contains the default prometheus starter config
file with the single prometheus scraping job.  Also added a template
cookbook hook so that users of this cookbook can wrap it and introduce
their own config for now until we can provide more complete
configuration via resources and discovery.