### PR TITLE
Fixed issue with init template and chef 11.x

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,8 +23,6 @@ suites:
     attributes:
       prometheus:
         init_style: 'init'
-        flags:
-          storage.remote.timeout: 45s
 
   - name: bluepill
     run_list:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased][unreleased]
+### Fixed
+- Fix init template path bug on chef 11.x
+
+
 ## [0.3.0] - 2015-05-11
 ### Fixed
 - Fixed cookbook badge in README
@@ -13,5 +18,6 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Initial release of prometheus cookbook
 
+[unreleased]: https://github.com/rayrod2030/chef-prometheus/compare/0.3.0...HEAD
 [0.3.0]: https://github.com/rayrod2030/chef-prometheus/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/rayrod2030/chef-prometheus/compare/0.1.0...0.2.0

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -104,7 +104,7 @@ when 'bluepill'
   end
 else
   template '/etc/init.d/prometheus' do
-    source "#{node['platform']}/prometheus.erb"
+    source 'prometheus.erb'
     owner 'root'
     group node['root_group']
     mode '0755'


### PR DESCRIPTION
Template path was being appended twice to the 
platform template path.  This fix should work for chef 
11.x and 12.x.