### PR TITLE
Removing a spec which tests that the prometheus.config file gets

### DIFF
--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -34,7 +34,6 @@ describe 'prometheus::default' do
 
   it 'renders a prometheus job configuration file and notifies prometheus to restart' do
     resource = chef_run.template('/opt/prometheus/prometheus.conf')
-    expect(chef_run).to render_file('/opt/prometheus/prometheus.conf').with_content(start_with('# Global default settings.'))
     expect(resource).to notify('service[prometheus]').to(:restart)
   end
 


### PR DESCRIPTION
rendered.  Now that we are generating this file using the accumulator
pattern we need a different way to test proper rendering of this config
file.  This PR simply removes this check in the meantime until we can
add a spec that works well with the accumulator pattern