### PR TITLE
Allow external management of prometheus.conf

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -63,6 +63,9 @@ default['prometheus']['checksum']                                               
 # then define it here. Example 'tar.bz2'
 default['prometheus']['file_extension']                                                   = ''
 
+# Should we allow external config changes?
+default['prometheus']['allow_external_config']                                            = false
+
 # Prometheus job configuration chef template name.
 default['prometheus']['job_config_template_name']                                         = 'prometheus.conf.erb'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -61,6 +61,8 @@ accumulator node['prometheus']['flags']['config.file'] do
   transform     { |jobs| jobs.sort_by(&:name) }
   variable_name :jobs
   notifies      :restart, 'service[prometheus]'
+
+  not_if { node['prometheus']['allow_external_config'] && File.exist?(node['prometheus']['flags']['config.file']) }
 end
 
 # -- Do the install -- #


### PR DESCRIPTION
So just after we merged #22, allowing easier configuration, I'd now like a change that takes this cookbook out of the config business. 

Context is in prometheus/prometheus#608. Basically the existing service discovery isn't quite doing what I need it to because of a detail in how Consul implements SRV lookups. Until we get that sorted I plan to use [consul-template](https://github.com/hashicorp/consul-template) to make sure all my nodes get written into the config correctly.

To do that, though, I need this cookbook to not care that my external process is writing a new config file. This seems like a fairly normal case (a wrapper cookbook that is opinionated about how the config gets created), so I think both config cases help expand what the cookbook can do.