### PR TITLE
Adding packages for centos

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,6 +32,9 @@ suites:
   - name: init
     run_list:
         - recipe[prometheus::default]
+    provisioner:
+        name: chef_zero
+        require_chef_omnibus: 11.12.4
     attributes:
       prometheus:
         init_style: 'init'

--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -19,6 +19,10 @@
 
 include_recipe 'ark::default'
 
+%w( curl tar bzip2 ).each do |pkg|
+  package pkg
+end
+
 dir_name = ::File.basename(node['prometheus']['dir'])
 dir_path = ::File.dirname(node['prometheus']['dir'])
 

--- a/test/integration/bluepill-binary/serverspec/binary_spec.rb
+++ b/test/integration/bluepill-binary/serverspec/binary_spec.rb
@@ -10,7 +10,7 @@ describe 'prometheus service' do
   end
 
   describe 'prometheus should be exposing metrics' do
-    describe command("wget 'http://localhost:9090/metrics' -q -O -") do
+    describe command("curl 'http://localhost:9090/metrics'") do
       its(:stdout) { should match(/prometheus_notifications_queue_capacity 100/) }
     end
   end

--- a/test/integration/default-binary/serverspec/binary_spec.rb
+++ b/test/integration/default-binary/serverspec/binary_spec.rb
@@ -10,7 +10,7 @@ describe 'prometheus service' do
   end
 
   describe 'prometheus should be exposing metrics' do
-    describe command("wget 'http://localhost:9090/metrics' -q -O -") do
+    describe command("curl 'http://localhost:9090/metrics'") do
       its(:stdout) { should match(/prometheus_notifications_queue_capacity 100/) }
     end
   end

--- a/test/integration/init-binary/serverspec/binary_spec.rb
+++ b/test/integration/init-binary/serverspec/binary_spec.rb
@@ -10,7 +10,7 @@ describe 'prometheus service' do
   end
 
   describe 'prometheus should be exposing metrics' do
-    describe command("wget 'http://localhost:9090/metrics' -q -O -") do
+    describe command("curl 'http://localhost:9090/metrics'") do
       its(:stdout) { should match(/prometheus_notifications_queue_capacity 100/) }
     end
   end


### PR DESCRIPTION
This PR covers the following: 

* Installs the `bzip2` package which is required by the binary install method and is not always installed by default on some distributions like Centos 7.

* Changes some serverspec tests to use `curl` for inspecting the prometheus endpoints.

* Uses chef 11 as a provisioner in a test suite to improve test coverage.