### PR TITLE
Add upstart init support for ubuntu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased][unreleased]
+### Added
+- Added upstart init for ubuntu platform.
 
 ## [0.5.1] - 2015-03-25
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ a user-defined location.
 ### service
 The `service` recipe configures Prometheus to run under a process supervisor.
 Default supervisors are chosen based on distribution. Currently supported
-supervisors are init, runit, systemd and bluepill.  (Upstart coming soon)
+supervisors are init, runit, systemd, upstart and bluepill.
 
 Resource/Provider
 -----------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,11 @@ default['prometheus']['install_method']                                         
 # Init style.
 case node['platform_family']
 when 'debian'
-  default['prometheus']['init_style']                                                     = 'runit'
+  if node['platform'] == 'ubuntu'
+    default['prometheus']['init_style']                                                   = 'upstart'
+  else
+    default['prometheus']['init_style']                                                   = 'runit'
+  end
 when 'rhel', 'fedora'
   if node['platform_version'].to_i >= 7
     default['prometheus']['init_style']                                                   = 'systemd'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -58,6 +58,17 @@ when 'systemd'
     action [:enable, :start]
   end
   # rubocop:enable Style/HashSyntax
+when 'upstart'
+  template '/etc/init/prometheus.conf' do
+    source 'upstart/prometheus.service.erb'
+    mode 0644
+    notifies :restart, 'service[prometheus]', :delayed
+  end
+
+  service 'prometheus' do
+    provider Chef::Provider::Service::Upstart
+    action [:enable, :start]
+  end
 else
   template '/etc/init.d/prometheus' do
     source 'prometheus.erb'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -128,6 +128,18 @@ describe 'prometheus::default' do
         expect(chef_run).to render_file('/etc/systemd/system/prometheus.service')
       end
     end
+
+    context 'upstart' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(file_cache_path: '/var/chef/cache') do |node|
+          node.set['prometheus']['init_style'] = 'upstart'
+        end.converge(described_recipe)
+      end
+
+      it 'renders an upstart job configuration file' do
+        expect(chef_run).to render_file('/etc/init/prometheus.conf')
+      end
+    end
   end
 
   # Test for binary.rb
@@ -217,6 +229,18 @@ describe 'prometheus::default' do
 
       it 'renders a systemd service file' do
         expect(chef_run).to render_file('/etc/systemd/system/prometheus.service')
+      end
+    end
+    context 'upstart' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(file_cache_path: '/var/chef/cache') do |node|
+          node.set['prometheus']['init_style'] = 'upstart'
+          node.set['prometheus']['install_method'] = 'binary'
+        end.converge(described_recipe)
+      end
+
+      it 'renders an upstart job configuration file' do
+        expect(chef_run).to render_file('/etc/init/prometheus.conf')
       end
     end
   end

--- a/templates/default/upstart/prometheus.service.erb
+++ b/templates/default/upstart/prometheus.service.erb
@@ -1,0 +1,14 @@
+description "Prometheus"
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on runlevel [016]
+
+respawn
+env GOMAXPROCS=<%= node['cpu']['total'] %>
+setuid <%= node['prometheus']['user'] %>
+setgid <%= node['prometheus']['user'] %>
+
+script
+  exec >> "<%= node['prometheus']['log_dir'] %>/prometheus.log"
+  exec 2>&1
+  exec <%= node['prometheus']['binary'] %> <%= generate_flags %>
+end script


### PR DESCRIPTION
Add upstart config file for ubuntu, set it as default. Standard init
script is still supported when explicitly selected.

I could not test non-binary machines in kitchen due to #34 ,but other than that kitchen seems happy.
This should close #4 