### PR TITLE
Create storage.local.path directory explicitly

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'rayrod2030@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures Prometheus'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.6.0'
+version          '0.6.1'
 # rubocop:enable Style/SingleSpaceBeforeFirstArg
 
 %w( ubuntu debian centos redhat fedora ).each do |os|

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,6 +37,13 @@ directory node['prometheus']['log_dir'] do
   recursive true
 end
 
+directory node['prometheus']['flags']['storage.local.path'] do
+  owner node['prometheus']['user']
+  group node['prometheus']['group']
+  mode '0755'
+  recursive true
+end
+
 # -- Write our Config -- #
 
 template node['prometheus']['flags']['config.file'] do


### PR DESCRIPTION
When using a custom storage.local.path, such as `/var/lib/prometheus`, the service will fail to start as this directory does not exist and can't be created. This directory can and should be explicitly created.

I was also curious why the default storage directory is `/tmp/metrics` - the `tmp` directory gets cleared on reboot and under other circumstances so using it for data storage seems like it has the potential to cause confusion and pain.